### PR TITLE
Added optional invincibility frames to health script

### DIFF
--- a/Assets/_Project/Scripts/Events.meta
+++ b/Assets/_Project/Scripts/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d213dac362e014a7f9efb2abbf37795d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/Events/OnValueChangedEventArgs.cs
+++ b/Assets/_Project/Scripts/Events/OnValueChangedEventArgs.cs
@@ -1,0 +1,7 @@
+using System;
+
+public class OnValueChangedArgs<T> : EventArgs
+{
+    public T value;
+    public T previousValue;
+}

--- a/Assets/_Project/Scripts/Events/OnValueChangedEventArgs.cs.meta
+++ b/Assets/_Project/Scripts/Events/OnValueChangedEventArgs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a9907fa752b04219a40d653ee34f0bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/Player/HealthSystem.cs
+++ b/Assets/_Project/Scripts/Player/HealthSystem.cs
@@ -9,23 +9,52 @@ namespace Player
         private int _hitPoints = 0;
         [SerializeField, Tooltip("Maximum hit points")] private int _maxHitPoints = 20;
         [SerializeField, Tooltip("Initial hit points, limited to max hit points")] private int _startingHitPoints = 20;
+        [SerializeField, Tooltip("If entity becomes invincible for a short time after taking damage")] private bool _hasDamageCooldown = true;
+        [SerializeField, Range(0, 3f), Tooltip("How long entity is invincible after taking damage")] private float _damageCooldown = 0.3f;
+        private float _damageCooldownTimeRemaining = 0;
 
         private void Awake()
         {
-            _hitPoints = Mathf.Max(_maxHitPoints, _startingHitPoints);
+            _hitPoints = Mathf.Min(_maxHitPoints, _startingHitPoints);
         }
 
         public event EventHandler OnDeath;
+        public event EventHandler OnInvincibleStarted;
+        public event EventHandler OnInvincibleEnd;
         public event EventHandler OnHitPointsChanged;
+
+        private void Update()
+        {
+            if (IsInvincible())
+            {
+                _damageCooldownTimeRemaining -= Time.deltaTime;
+                if (_damageCooldownTimeRemaining <= 0)
+                {
+                    OnInvincibleEnded?.Invoke(this, EventArgs.Empty);
+                }
+            }
+        }
 
         public void TakeDamage(int amount)
         {
+            if (IsInvincible())
+            {
+                return;
+            }
+
             _hitPoints -= amount;
-            OnHitPointsChanged?.Invoke(this, EventArgs.Empty);
             _hitPoints = Mathf.Max(_hitPoints, 0);
+
+            OnHitPointsChanged?.Invoke(this, _hitPoints);
+
             if (_hitPoints == 0)
             {
                 Die();
+            }
+            else if (_hasDamageCooldown)
+            {
+                _damageCooldownTimeRemaining = _damageCooldown;
+                OnInvincibleStarted?.Invoke(this.EventArgs.Empty);
             }
         }
 
@@ -38,6 +67,16 @@ namespace Player
         public float GetHealthNormalised()
         {
             return (float)(_hitPoints) / _maxHitPoints;
+        }
+
+        public bool IsDamageable()
+        {
+            return !_hasDamageCooldown || (_hasDamageCooldown && _damageCooldownTimeRemaining <= 0);
+        }
+
+        public bool IsInvincible()
+        {
+            return _hasDamageCooldown && _damageCooldownTimeRemaining > 0;
         }
 
         private void Die()


### PR DESCRIPTION
As requested by @Bolrik, have added optional invincibility frames to the health script with configurable time window and events. 
Also adds previous and new health values to the OnHealthChanged event