### PR TITLE
CI - Put back the ci/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,5 @@ steam_build_output/*
 
 # Filetypes
 *.sh
+!ci/*.sh
 *.xcf

--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+mkdir -p /root/.cache/unity3d
+mkdir -p /root/.local/share/unity3d/Unity/
+set +x
+
+UPPERCASE_BUILD_TARGET=${BUILD_TARGET^^};
+
+if [ $UPPERCASE_BUILD_TARGET = "ANDROID" ]
+then
+    if [ -n $ANDROID_KEYSTORE_BASE64 ]
+	then
+        echo '$ANDROID_KEYSTORE_BASE64 found, decoding content into keystore.keystore'
+        echo $ANDROID_KEYSTORE_BASE64 | base64 --decode > keystore.keystore
+    else
+        echo '$ANDROID_KEYSTORE_BASE64'" env var not found, building with Unity's default debug keystore"
+    fi
+fi
+
+LICENSE="UNITY_LICENSE_"$UPPERCASE_BUILD_TARGET
+
+if [ -z "${!LICENSE}" ]
+then
+    echo "$LICENSE env var not found, using default UNITY_LICENSE env var"
+    LICENSE=UNITY_LICENSE
+else
+    echo "Using $LICENSE env var"
+fi
+
+echo "Writing $LICENSE to license file /root/.local/share/unity3d/Unity/Unity_lic.ulf"
+echo "${!LICENSE}" | tr -d '\r' > /root/.local/share/unity3d/Unity/Unity_lic.ulf
+
+set -x

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+echo "Building for $BUILD_TARGET"
+
+export BUILD_PATH=$UNITY_DIR/Builds/$BUILD_TARGET/
+mkdir -p $BUILD_PATH
+
+${UNITY_EXECUTABLE:-xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' unity-editor} \
+  -projectPath $UNITY_DIR \
+  -quit \
+  -batchmode \
+  -nographics \
+  -buildTarget $BUILD_TARGET \
+  -customBuildTarget $BUILD_TARGET \
+  -customBuildName $BUILD_NAME \
+  -customBuildPath $BUILD_PATH \
+  -executeMethod BuildCommand.PerformBuild \
+  -logFile /dev/stdout
+
+UNITY_EXIT_CODE=$?
+
+if [ $UNITY_EXIT_CODE -eq 0 ]; then
+  echo "Run succeeded, no failures occurred";
+elif [ $UNITY_EXIT_CODE -eq 2 ]; then
+  echo "Run succeeded, some tests failed";
+elif [ $UNITY_EXIT_CODE -eq 3 ]; then
+  echo "Run failure (other failure)";
+else
+  echo "Unexpected exit code $UNITY_EXIT_CODE";
+fi
+
+ls -la $BUILD_PATH
+[ -n "$(ls -A $BUILD_PATH)" ] # fail job if build folder is empty

--- a/ci/docker_build.sh
+++ b/ci/docker_build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+docker run \
+  -e BUILD_NAME \
+  -e UNITY_LICENSE \
+  -e BUILD_TARGET \
+  -e UNITY_USERNAME \
+  -e UNITY_PASSWORD \
+  -w /project/ \
+  -v $UNITY_DIR:/project/ \
+  $IMAGE_NAME \
+  /bin/bash -c "/project/ci/before_script.sh && /project/ci/build.sh"

--- a/ci/docker_test.sh
+++ b/ci/docker_test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+docker run \
+  -e UNITY_LICENSE \
+  -e TEST_PLATFORM \
+  -e UNITY_USERNAME \
+  -e UNITY_PASSWORD \
+  -w /project/ \
+  -v $UNITY_DIR:/project/ \
+  $IMAGE_NAME \
+  /bin/bash -c "/project/ci/before_script.sh && /project/ci/test.sh"

--- a/ci/get_activation_file.sh
+++ b/ci/get_activation_file.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+activation_file=${UNITY_ACTIVATION_FILE:-./unity3d.alf}
+
+if [[ -z "${UNITY_USERNAME}" ]] || [[ -z "${UNITY_PASSWORD}" ]]; then
+  echo "UNITY_USERNAME or UNITY_PASSWORD environment variables are not set, please refer to instructions in the readme and add these to your secret environment variables."
+  exit 1
+fi
+
+xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' \
+  unity-editor \
+    -logFile /dev/stdout \
+    -batchmode \
+    -nographics \
+    -username "$UNITY_USERNAME" -password "$UNITY_PASSWORD" |
+      tee ./unity-output.log
+
+cat ./unity-output.log |
+  grep 'LICENSE SYSTEM .* Posting *' |
+  sed 's/.*Posting *//' > "${activation_file}"
+
+# Fail job if unity.alf is empty
+ls "${UNITY_ACTIVATION_FILE:-./unity3d.alf}"
+exit_code=$?
+
+if [[ ${exit_code} -eq 0 ]]; then
+  echo ""
+  echo ""
+  echo "### Congratulations! ###"
+  echo "${activation_file} was generated successfully!"
+  echo ""
+  echo "### Next steps ###"
+  echo ""
+  echo "Complete the activation process manually"
+  echo ""
+  echo "   1. Download the artifact which should contain ${activation_file}"
+  echo "   2. Visit https://license.unity3d.com/manual"
+  echo "   3. Upload ${activation_file} in the form"
+  echo "   4. Answer questions (unity pro vs personal edition, both will work, just pick the one you use)"
+  echo "   5. Download 'Unity_v2019.x.ulf' file (year should match your unity version here, 'Unity_v2018.x.ulf' for 2018, etc.)"
+  echo "   6. Copy the content of 'Unity_v2019.x.ulf' license file to your CI's environment variable 'UNITY_LICENSE'. (Open your project's parameters > CI/CD > Variables and add 'UNITY_LICENSE' as the key and paste the content of the license file into the value)"
+  echo ""
+  echo "Once you're done, hit retry on the pipeline where other jobs failed, or just push another commit. Things should be green"
+  echo ""
+  echo "(optional) For more details on why this is not fully automated, visit https://gitlab.com/gableroux/unity3d-gitlab-ci-example/issues/73"
+else
+  echo "License file could not be found at ${UNITY_ACTIVATION_FILE:-./unity3d.alf}"
+fi
+exit $exit_code

--- a/ci/release_before_script.sh
+++ b/ci/release_before_script.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+set +x
+
+# Check for changelog.
+if test -f "$UNITY_DIR/RELEASE.md"; then
+    echo 'Found release file. Adding description variable.'
+    EXTRA_DESCRIPTION=$(cat $UNITY_DIR/RELEASE.md)
+fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -x
+
+echo "Testing for $TEST_PLATFORM"
+
+CODE_COVERAGE_PACKAGE="com.unity.testtools.codecoverage"
+PACKAGE_MANIFEST_PATH="Packages/manifest.json"
+
+${UNITY_EXECUTABLE:-xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' unity-editor} \
+  -projectPath $UNITY_DIR \
+  -runTests \
+  -testPlatform $TEST_PLATFORM \
+  -testResults $UNITY_DIR/$TEST_PLATFORM-results.xml \
+  -logFile /dev/stdout \
+  -batchmode \
+  -nographics \
+  -enableCodeCoverage \
+  -coverageResultsPath $UNITY_DIR/$TEST_PLATFORM-coverage \
+  -coverageOptions "generateAdditionalMetrics;generateHtmlReport;generateHtmlReportHistory;generateBadgeReport;assemblyFilters:+Assembly-CSharp" \
+  -debugCodeOptimization
+
+UNITY_EXIT_CODE=$?
+
+if [ $UNITY_EXIT_CODE -eq 0 ]; then
+  echo "Run succeeded, no failures occurred";
+elif [ $UNITY_EXIT_CODE -eq 2 ]; then
+  echo "Run succeeded, some tests failed";
+elif [ $UNITY_EXIT_CODE -eq 3 ]; then
+  echo "Run failure (other failure)";
+else
+  echo "Unexpected exit code $UNITY_EXIT_CODE";
+fi
+
+if grep $CODE_COVERAGE_PACKAGE $PACKAGE_MANIFEST_PATH; then
+  cat $UNITY_DIR/$TEST_PLATFORM-coverage/Report/Summary.xml | grep Linecoverage
+  mv $UNITY_DIR/$TEST_PLATFORM-coverage/$CI_PROJECT_NAME-opencov/*Mode/TestCoverageResults_*.xml $UNITY_DIR/$TEST_PLATFORM-coverage/coverage.xml
+  rm -r $UNITY_DIR/$TEST_PLATFORM-coverage/$CI_PROJECT_NAME-opencov/
+else
+  {
+    echo -e "\033[33mCode Coverage package not found in $PACKAGE_MANIFEST_PATH. Please install the package \"Code Coverage\" through Unity's Package Manager to enable coverage reports.\033[0m"
+  } 2> /dev/null
+fi
+
+cat $UNITY_DIR/$TEST_PLATFORM-results.xml | grep test-run | grep Passed
+exit $UNITY_EXIT_CODE


### PR DESCRIPTION
Its missing from the `develop` branch currently, but it should be there, so putting it back.

Copy-pasted the `ci/` directory from the `main` branch.

My guess is this happened because of the `*.sh` rule in `.gitignore` so I added an exception in `.gitignore` to allow shell scripts in the `ci/` directory.
