### PR TITLE
Fix: Backend - Fix Local Startup Script DDB

### DIFF
--- a/backend/scripts/start-local.sh
+++ b/backend/scripts/start-local.sh
@@ -67,8 +67,8 @@ else
                         \"NonKeyAttributes\":[\"pk\",\"levelName\",\"levelStatus\"]
                     },
                     \"ProvisionedThroughput\": {
-                        \"ReadCapacityUnits\": 0,
-                        \"WriteCapacityUnits\": 0
+                        \"ReadCapacityUnits\": 1,
+                        \"WriteCapacityUnits\": 1
                     }
                 },
                 {
@@ -80,8 +80,8 @@ else
                         \"NonKeyAttributes\":[\"pk\",\"levelName\",\"levelCreatorId\"]
                     },
                     \"ProvisionedThroughput\": {
-                        \"ReadCapacityUnits\": 0,
-                        \"WriteCapacityUnits\": 0
+                        \"ReadCapacityUnits\": 1,
+                        \"WriteCapacityUnits\": 1
                     }
                 }
             ]" \


### PR DESCRIPTION
`ProvisionedThroughput` in the local startup script has to be at least 1, apparently
