### PR TITLE
Backend: Pagination for Get All Levels Query

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -75,10 +75,8 @@ The backend API would have the following APIs:
 **GET `/levels`**
 
 **Query Params:**
-* `status` (Required) filters to levels of the provided status
-* `limit` (Optional) page limit, default: 10
-* `skip` (Optional) page skip, default: 0
-* `creator-id` (Optional) filters to levels for a creator
+* `cursor` (Optional) Provide the cursor value of a prior request to get the next page
+* `draft` (Optional) Queries for `DRAFT` levels rather than `PUBLISHED` levels.
 
 **Response:**
 ```json
@@ -95,9 +93,20 @@ The backend API would have the following APIs:
       "createdAt": 1686495335,
       "updatedAt": 1686495335,
     }
-  ]
+  ],
+  "cursor": "UUID" // For pagination - simply pass this as the 'cursor' param to another request to get the next page
 }
 ```
+
+Pagination is cursor-based (rather than offset) 
+because that's what DynamDB supports out-of-the-box 
+(https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.Pagination.html).
+
+The UI this would most naturally support would involve hitting the limit, 
+then showing a "Load More" button (or something like that),
+then fetching the next page of results.
+
+For flexibility, I've also added a "page limit" query param so the client can fetch more than 10 levels in a single page.
 
 ### Get Level
 

--- a/backend/requests/levels/get-all.sh
+++ b/backend/requests/levels/get-all.sh
@@ -3,4 +3,7 @@ set -eo pipefail
 
 . requests/set-vars.sh
 
-curl ${URL} | python3 -m json.tool
+curl ${URL}?'limit=5' | python3 -m json.tool
+
+# To get the second page:
+# curl ${URL}?'limit=5&cursor=fadefc47-f92d-449a-a01f-38e8dca88365' | python3 -m json.tool

--- a/backend/scripts/query-ddb.sh
+++ b/backend/scripts/query-ddb.sh
@@ -1,0 +1,48 @@
+TABLE=editarrr-level-storage
+
+# Get
+# aws dynamodb get-item \
+#     --table-name $TABLE \
+#     --key '{ "pk": { "S": "LEVEL#4a414edd-da39-4412-8dda-cc484c77966c"}, "sk": { "S": "LEVEL#4a414edd-da39-4412-8dda-cc484c77966c"} }'
+
+# Get First Page of a List
+aws dynamodb query \
+  --table-name $TABLE \
+  --index-name "levelStatus-levelUpdatedAt-index" \
+  --select "ALL_PROJECTED_ATTRIBUTES" \
+  --limit 10 \
+  --no-scan-index-forward \
+  --key-condition-expression "levelStatus = :status" \
+  --expression-attribute-values '{ ":status": { "S": "PUBLISHED" } }'
+
+# Get the second page
+# aws dynamodb query \
+#   --table-name $TABLE \
+#   --index-name "levelStatus-levelUpdatedAt-index" \
+#   --select "ALL_PROJECTED_ATTRIBUTES" \
+#   --limit 10 \
+#   --no-scan-index-forward \
+#   --key-condition-expression "levelStatus = :status" \
+#   --expression-attribute-values '{ ":status": { "S": "PUBLISHED" } }' \
+#   --exclusive-start-key '{
+#         "levelStatus": {
+#             "S": "PUBLISHED"
+#         },
+#         "levelUpdatedAt": {
+#             "N": "1698515874383"
+#         },
+#         "sk": {
+#             "S": "LEVEL#4a414edd-da39-4412-8dda-cc484c77966c"
+#         },
+#         "pk": {
+#             "S": "LEVEL#4a414edd-da39-4412-8dda-cc484c77966c"
+#         }
+#     }'
+
+# Get Total Count
+# aws dynamodb query \
+#   --table-name $TABLE \
+#   --index-name "levelStatus-levelUpdatedAt-index" \
+#   --select "COUNT" \
+#   --key-condition-expression "levelStatus = :status" \
+#   --expression-attribute-values '{ ":status": { "S": "PUBLISHED" } }'


### PR DESCRIPTION
Pagination is cursor-based (rather than offset)
because that's what DynamDB supports out-of-the-box (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.Pagination.html).

The UI this would most naturally support would involve hitting the limit, then showing a "Load More" button (or something like that), then fetching the next page of results.

For flexibility, I've also added a "page limit" query param so the client can fetch more than 10 levels in a single page.