### PR TITLE
Backend: Switching From Scores as Strings to Scores as Numbers

### DIFF
--- a/backend/lambda/api/scores.mjs
+++ b/backend/lambda/api/scores.mjs
@@ -12,8 +12,11 @@ export class ScoresApi {
     async postScore(levelId, requestJSON) {
         var score = requestJSON.score;
         if (!score) throw new BadRequestException(`'score' must be provided in the request.`);
-        score = score.replace(/,/g, '.');
-        if (isNaN(parseFloat(score))) throw new BadRequestException(`'score' must be a number`);
+        if (typeof score === "string") {
+            score = score.replace(/,/g, '.');
+            score = parseFloat(score);
+        } 
+        if (isNaN(score)) throw new BadRequestException(`'score' must be a number`);
         var scoreLevelName = requestJSON.code;
         if (!scoreLevelName) throw new BadRequestException(`'code' must be provided in the request.`);
         var scoreCreatorId = requestJSON.creator;
@@ -41,7 +44,7 @@ export class ScoresApi {
             var dbScore = allScoresForLevel[i];
 
             totalNumberOfScores++;
-            sumOfAllScores += parseFloat(dbScore.score);
+            sumOfAllScores += dbScore.scoreNumber;
         }
         var avgScore = sumOfAllScores / allScoresForLevel.length;
         
@@ -128,7 +131,7 @@ export class ScoresApi {
             responseScores.push({
                 "scoreId": id,
                 "levelId": levelId,
-                "score": dbScore.score,
+                "score": dbScore.scoreNumber,
                 "code": dbScore.scoreLevelName,
                 "creator": {
                     "id": dbScore.scoreCreatorId,

--- a/backend/lambda/api/scores.test.mjs
+++ b/backend/lambda/api/scores.test.mjs
@@ -19,7 +19,7 @@ var scoresApi;
 var tableNameScores = "editarrr-score-storage";
 var tableNameLevels = "editarrr-level-storage";
 
-var indexLevelNameScore = "scoreLevelName-score-index";
+var indexLevelNameScore = "scoreLevelName-scoreNumber-index";
 
 describe('PostScore', function () {
     
@@ -59,7 +59,7 @@ describe('PostScore', function () {
 
         ddbClientSendStub.withArgs(match.has("input", {
             TableName: tableNameScores,
-            IndexName: "scoreLevelName-score-index",
+            IndexName: "scoreLevelName-scoreNumber-index",
             // TODO can we do a subset of attributes?
             Select: "ALL_PROJECTED_ATTRIBUTES",
             ScanIndexForward: true,
@@ -70,10 +70,10 @@ describe('PostScore', function () {
         })).returns({
             "Items": [
                 {
-                    score: "1.0"
+                    score: 1.0
                 },
                 {
-                    score: "3.0"
+                    score: 3.0
                 }
             ]
         });
@@ -91,7 +91,7 @@ describe('PostScore', function () {
             match.has("TableName", tableNameScores).and(
             match.has("Item", 
                 match.has("pk", `LEVEL#${levelId}`).and(
-                match.has("score", "1.0")),
+                match.has("score", 1.0)),
         ))));
         assert.calledWith(ddbClientSendStub, match.has("input", {
             TableName: tableNameLevels,
@@ -135,7 +135,7 @@ describe('PostScore', function () {
 
         ddbClientSendStub.withArgs(match.has("input", {
             TableName: tableNameScores,
-            IndexName: "scoreLevelName-score-index",
+            IndexName: "scoreLevelName-scoreNumber-index",
             // TODO can we do a subset of attributes?
             Select: "ALL_PROJECTED_ATTRIBUTES",
             ScanIndexForward: true,
@@ -146,10 +146,10 @@ describe('PostScore', function () {
         })).returns({
             "Items": [
                 {
-                    score: "1.0"
+                    score: 1.0
                 },
                 {
-                    score: "3.0"
+                    score: 3.0
                 }
             ]
         });
@@ -167,7 +167,7 @@ describe('PostScore', function () {
             match.has("TableName", tableNameScores).and(
             match.has("Item", 
                 match.has("pk", `LEVEL#${levelId}`).and(
-                match.has("score", "1.234")),
+                match.has("score", 1.234)),
         ))));
         assert.calledWith(ddbClientSendStub, match.has("input", {
             TableName: tableNameLevels,
@@ -242,7 +242,7 @@ describe('GetPagedScores', function() {
                 {
                     "pk": "LEVEL#5246cf90-7f7f-4074-aea1-ba543d27ed63",
                     "sk": "SCORE#52dff6ed-eb42-4ec1-81d6-d36db8d048d6",
-                    "score": "0.6215752",
+                    "scoreNumber": 0.6215752,
                     "scoreLevelName": "29995",
                     "scoreSubmittedAt": 1698964301163,
                     "scoreCreatorId": "e0f86b03-7a0f-45d8-a66d-322c4e1196e5",
@@ -251,7 +251,7 @@ describe('GetPagedScores', function() {
                 {
                     "pk": "LEVEL#5246cf90-7f7f-4074-aea1-ba543d27ed63",
                     "sk": "SCORE#6580188b-eec0-44a9-9e56-2de2e5b9a937",
-                    "score": "1.0",
+                    "scoreNumber": 1.0,
                     "scoreLevelName": "29995",
                     "scoreSubmittedAt": 1698938196593,
                     "scoreCreatorId": "2cbe4992-950e-43bc-9fec-4e6138b5ce74",
@@ -276,7 +276,7 @@ describe('GetPagedScores', function() {
                 {
                     "scoreId": "52dff6ed-eb42-4ec1-81d6-d36db8d048d6",
                     "levelId": "5246cf90-7f7f-4074-aea1-ba543d27ed63",
-                    "score": "0.6215752",
+                    "score": 0.6215752,
                     "code": "29995",
                     "creator": {
                         "id": "e0f86b03-7a0f-45d8-a66d-322c4e1196e5",
@@ -287,7 +287,7 @@ describe('GetPagedScores', function() {
                 {
                     "scoreId": "6580188b-eec0-44a9-9e56-2de2e5b9a937",
                     "levelId": "5246cf90-7f7f-4074-aea1-ba543d27ed63",
-                    "score": "1.0",
+                    "score": 1.0,
                     "code": "29995",
                     "creator": {
                         "id": "2cbe4992-950e-43bc-9fec-4e6138b5ce74",
@@ -323,7 +323,7 @@ describe('GetPagedScores', function() {
                 {
                     "pk": "LEVEL#5246cf90-7f7f-4074-aea1-ba543d27ed63",
                     "sk": "SCORE#6580188b-eec0-44a9-9e56-2de2e5b9a937",
-                    "score": "1.0",
+                    "scoreNumber": 1.0,
                     "scoreLevelName": "29995",
                     "scoreSubmittedAt": 1698938196593,
                     "scoreCreatorId": "2cbe4992-950e-43bc-9fec-4e6138b5ce74",
@@ -332,7 +332,7 @@ describe('GetPagedScores', function() {
                 {
                     "pk": "LEVEL#5246cf90-7f7f-4074-aea1-ba543d27ed63",
                     "sk": "SCORE#52dff6ed-eb42-4ec1-81d6-d36db8d048d6",
-                    "score": "0.6215752",
+                    "scoreNumber": 0.6215752,
                     "scoreLevelName": "29995",
                     "scoreSubmittedAt": 1698964301163,
                     "scoreCreatorId": "e0f86b03-7a0f-45d8-a66d-322c4e1196e5",
@@ -357,7 +357,7 @@ describe('GetPagedScores', function() {
                 {
                     "scoreId": "6580188b-eec0-44a9-9e56-2de2e5b9a937",
                     "levelId": "5246cf90-7f7f-4074-aea1-ba543d27ed63",
-                    "score": "1.0",
+                    "score": 1.0,
                     "code": "29995",
                     "creator": {
                         "id": "2cbe4992-950e-43bc-9fec-4e6138b5ce74",
@@ -368,7 +368,7 @@ describe('GetPagedScores', function() {
                 {
                     "scoreId": "52dff6ed-eb42-4ec1-81d6-d36db8d048d6",
                     "levelId": "5246cf90-7f7f-4074-aea1-ba543d27ed63",
-                    "score": "0.6215752",
+                    "score": 0.6215752,
                     "code": "29995",
                     "creator": {
                         "id": "e0f86b03-7a0f-45d8-a66d-322c4e1196e5",
@@ -404,7 +404,7 @@ describe('GetPagedScores', function() {
                 {
                     "pk": "LEVEL#5246cf90-7f7f-4074-aea1-ba543d27ed63",
                     "sk": "SCORE#52dff6ed-eb42-4ec1-81d6-d36db8d048d6",
-                    "score": "0.6215752",
+                    "scoreNumber": 0.6215752,
                     "scoreLevelName": "29995",
                     "scoreSubmittedAt": 1698964301163,
                     "scoreCreatorId": "e0f86b03-7a0f-45d8-a66d-322c4e1196e5",
@@ -414,7 +414,7 @@ describe('GetPagedScores', function() {
             "LastEvaluatedKey": {
                 "pk": "LEVEL#5246cf90-7f7f-4074-aea1-ba543d27ed63",
                 "sk": "SCORE#52dff6ed-eb42-4ec1-81d6-d36db8d048d6",
-                "score": "0.6215752",
+                "scoreNumber": 0.6215752,
             },
         });
 
@@ -434,7 +434,7 @@ describe('GetPagedScores', function() {
                 {
                     "scoreId": "52dff6ed-eb42-4ec1-81d6-d36db8d048d6",
                     "levelId": "5246cf90-7f7f-4074-aea1-ba543d27ed63",
-                    "score": "0.6215752",
+                    "score": 0.6215752,
                     "code": "29995",
                     "creator": {
                         "id": "e0f86b03-7a0f-45d8-a66d-322c4e1196e5",
@@ -466,7 +466,7 @@ describe('GetPagedScores', function() {
             "Item": {
                 "pk": "LEVEL#5246cf90-7f7f-4074-aea1-ba543d27ed63",
                 "sk": "SCORE#52dff6ed-eb42-4ec1-81d6-d36db8d048d6",
-                "score": "0.6215752",
+                "score": 0.6215752,
                 "scoreLevelName": "29995",
                 "scoreSubmittedAt": 1698964301163,
                 "scoreCreatorId": "e0f86b03-7a0f-45d8-a66d-322c4e1196e5",
@@ -487,14 +487,14 @@ describe('GetPagedScores', function() {
             ExclusiveStartKey: {
                 "pk": "LEVEL#5246cf90-7f7f-4074-aea1-ba543d27ed63",
                 "sk": "SCORE#52dff6ed-eb42-4ec1-81d6-d36db8d048d6",
-                "score": "0.6215752",
+                "score": 0.6215752,
             },
         })).returns({
             "Items":[
                 {
                     "pk": "LEVEL#5246cf90-7f7f-4074-aea1-ba543d27ed63",
                     "sk": "SCORE#6580188b-eec0-44a9-9e56-2de2e5b9a937",
-                    "score": "1.0",
+                    "scoreNumber": 1.0,
                     "scoreLevelName": "29995",
                     "scoreSubmittedAt": 1698938196593,
                     "scoreCreatorId": "2cbe4992-950e-43bc-9fec-4e6138b5ce74",
@@ -519,7 +519,7 @@ describe('GetPagedScores', function() {
                 {
                     "scoreId": "6580188b-eec0-44a9-9e56-2de2e5b9a937",
                     "levelId": "5246cf90-7f7f-4074-aea1-ba543d27ed63",
-                    "score": "1.0",
+                    "score": 1.0,
                     "code": "29995",
                     "creator": {
                         "id": "2cbe4992-950e-43bc-9fec-4e6138b5ce74",
@@ -554,7 +554,7 @@ describe('GetPagedScores', function() {
                 {
                     "pk": "LEVEL#5246cf90-7f7f-4074-aea1-ba543d27ed63",
                     "sk": "SCORE#52dff6ed-eb42-4ec1-81d6-d36db8d048d6",
-                    "score": "0.6215752",
+                    "scoreNumber": 0.6215752,
                     "scoreLevelName": "29995",
                     "scoreSubmittedAt": 1698964301163,
                     "scoreCreatorId": "e0f86b03-7a0f-45d8-a66d-322c4e1196e5",
@@ -563,7 +563,7 @@ describe('GetPagedScores', function() {
                 {
                     "pk": "LEVEL#5246cf90-7f7f-4074-aea1-ba543d27ed63",
                     "sk": "SCORE#6580188b-eec0-44a9-9e56-2de2e5b9a937",
-                    "score": "1.0",
+                    "scoreNumber": 1.0,
                     "scoreLevelName": "29995",
                     "scoreSubmittedAt": 1698938196593,
                     "scoreCreatorId": "2cbe4992-950e-43bc-9fec-4e6138b5ce74",
@@ -572,7 +572,7 @@ describe('GetPagedScores', function() {
                 {
                     "pk": "LEVEL#5246cf90-7f7f-4074-aea1-ba543d27ed63",
                     "sk": "SCORE#6580188b-eec0-44a9-9e56-2de2e5b9a937",
-                    "score": "1.0",
+                    "scoreNumber": 1.0,
                     "scoreLevelName": "29995",
                     "scoreSubmittedAt": 1698938196593,
                     "scoreCreatorId": "2cbe4992-950e-43bc-9fec-4e6138b5ce74",
@@ -597,7 +597,7 @@ describe('GetPagedScores', function() {
                 {
                     "scoreId": "52dff6ed-eb42-4ec1-81d6-d36db8d048d6",
                     "levelId": "5246cf90-7f7f-4074-aea1-ba543d27ed63",
-                    "score": "0.6215752",
+                    "score": 0.6215752,
                     "code": "29995",
                     "creator": {
                         "id": "e0f86b03-7a0f-45d8-a66d-322c4e1196e5",

--- a/backend/lambda/db/scores.mjs
+++ b/backend/lambda/db/scores.mjs
@@ -6,7 +6,7 @@ import { uuidv4 } from "../utils.mjs";
 
 const tableName = "editarrr-score-storage";
 
-const indexScoreIdScore = "scoreLevelName-score-index"; // Note: I think the index was accidentally named this way - the index's pk is the main pk
+const indexScoreIdScore = "scoreLevelName-scoreNumber-index"; // Note: I think the index was accidentally named this way - the index's pk is the main pk
 
 // Because JS doesn't have enums...
 export class ScoresSortOptions {
@@ -31,7 +31,7 @@ const sortOptionToIndex = {
 }
 
 const sortOptionToAttributeName = {
-    [ScoresSortOptions.SCORE]: "score",
+    [ScoresSortOptions.SCORE]: "scoreNumber",
 }
 
 export class ScoresDbClient {
@@ -55,7 +55,7 @@ export class ScoresDbClient {
                 Item: {
                     pk: `LEVEL#${levelId}`,
                     sk: `SCORE#${generatedScoreId}`,
-                    score: score,
+                    scoreNumber: score,
                     scoreLevelName: scoreLevelName,
                     scoreCreatorId: scoreCreatorId,
                     scoreCreatorName: scoreCreatorName,

--- a/backend/requests/scores/post.sh
+++ b/backend/requests/scores/post.sh
@@ -10,7 +10,7 @@ fi
 
 curl -X "POST" -H "Content-Type: application/json" -d \
     '{
-        "score": "7.0", 
+        "score": "10,11", 
         "code": "29995",
         "creator": "2cbe4992-950e-43bc-9fec-4e6138b5ce74",
         "creatorName": "Murphys dad"

--- a/backend/scripts/migrations/score-strings-to-score-numbers.sh
+++ b/backend/scripts/migrations/score-strings-to-score-numbers.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -eo pipefail
+
+TABLE="editarrr-score-storage"
+
+# Step 1: Get all items from the DynamoDB table
+items=$(aws dynamodb scan --table-name $TABLE --output json --query 'Items')
+
+# Step 2: Process each item
+echo "${items}" | jq -c '.[]' | while IFS= read -r item; do
+    # Check if "score" attribute exists in the item
+    if echo "${item}" | jq -e 'has("score")' > /dev/null; then
+        # Extract the "score" attribute from the item
+        score=$(echo "${item}" | jq -r '.score.S')
+
+        # Convert the "score" from string to float
+        scoreFloat=$(echo "${score}" | awk '{printf "%.2f", $0}')
+
+        # Delete the "score" attribute
+        updatedItem=$(echo "${item}" | jq 'del(.score)')
+
+        # Add the new "scoreNumber" attribute with the float value
+        updatedItem=$(echo "${updatedItem}" | jq --arg scoreFloat "${scoreFloat}" '. + {scoreNumber: {N: $scoreFloat}}')
+
+        echo "Making update ${updatedItem}"
+        
+        # Check if RUN is set to true before executing put-item
+        if [ "$RUN" = true ]; then
+            # Update the item in the DynamoDB table
+            aws dynamodb put-item --table-name $TABLE --item "${updatedItem}" --return-consumed-capacity TOTAL
+        fi
+    else
+        echo "Item does not have a 'score' attribute. Skipping..."
+    fi
+done

--- a/backend/terraform/4-dynamodb-table.tf
+++ b/backend/terraform/4-dynamodb-table.tf
@@ -186,9 +186,15 @@ resource "aws_dynamodb_table" "editarrr-score-storage" {
   # pk: LEVEL#<levelId>
   # sk: SCORE#<score>
 
+  # DEPRECATED - use 'scoreNumber' instead. Can get rid of this once we migrate
   attribute {
     name = "score"
     type = "S" # Number of seconds 0015.123
+  }
+
+  attribute {
+    name = "scoreNumber"
+    type = "N" # Number of seconds, e.g. 10.1234
   }
 
   #  attribute {
@@ -212,10 +218,21 @@ resource "aws_dynamodb_table" "editarrr-score-storage" {
   #   type = "M" # JSON Blob
   # }
 
+  # DEPRECATED - use scoreLevelName-scoreNumber-index instead. Can get rid of this once we migrate
   global_secondary_index {
     name            = "scoreLevelName-score-index"
     hash_key        = "pk"
     range_key       = "score"  // sort key
+    projection_type = "INCLUDE"
+    non_key_attributes = [ "sk", "pk", "scoreLevelName", "scoreCreatorName", "scoreSubmittedAt", "scoreCreatorId"]
+    write_capacity  = 0
+    read_capacity   = 0
+  }
+
+  global_secondary_index {
+    name            = "scoreLevelName-scoreNumber-index"
+    hash_key        = "pk"
+    range_key       = "scoreNumber"  // sort key
     projection_type = "INCLUDE"
     non_key_attributes = [ "sk", "pk", "scoreLevelName", "scoreCreatorName", "scoreSubmittedAt", "scoreCreatorId"]
     write_capacity  = 0


### PR DESCRIPTION
Includes:
* Terraform updates to add a `scoreNumber` attribute that is a `Number` instead of a `String` (we can get rid of the `score` attribute and the GSI once we migrate over all the existing scores)
* Lambda updates to handle the number from the DB. Also, convert all the strings to numbers in the API request, so the API can still handle strings being passed to it
* Includes a script that has a migration (using the AWS CLI and JQ) to take all the existing `score` strings and replacing them with `scoreNumber` numbers

I've run the Terraform deploy and migration in `develop`. and it all seems to be working as far as I can tell (existing functionality, plus sorting with 10 seems to work, and commas are replaced with periods)