### PR TITLE
Achievement restriction

### DIFF
--- a/Assets/_Project/Scripts/Level/LevelState.cs
+++ b/Assets/_Project/Scripts/Level/LevelState.cs
@@ -8,8 +8,8 @@ namespace Editarrr.Level
     [Serializable]
     public class LevelState
     {
-        public string Creator { get; private set; } = "";
-        public string CreatorName { get; private set; } = "";
+        public string Creator { get; private set; } = ""; //guid
+        public string CreatorName { get; private set; } = ""; //chosen user name
         public bool Published { get; private set; }
 
         public string Code { get; private set; }

--- a/Assets/_Project/Scripts/Singletons/AchievementManager.cs
+++ b/Assets/_Project/Scripts/Singletons/AchievementManager.cs
@@ -1,8 +1,10 @@
 using System;
+using Editarrr.Level;
 using Editarrr.LevelEditor;
 using Gameplay;
 using Player;
 using SteamIntegration;
+using Systems;
 using UI;
 using UnityEngine;
 
@@ -105,9 +107,11 @@ namespace Singletons
 
         private void HandleAchievementProgress(ThresholdAchievement achievement, bool needsCode = false)
         {
+            var level = FindObjectOfType<LevelPlaySystem>().Manager.Level;
             var saveString = needsCode ? achievement.SavePrefString + _code : achievement.SavePrefString;
+            var currentPlayerID = PreferencesManager.Instance.GetUserId();
 
-            if (saveString != "")
+            if (saveString != "" && level.Creator != currentPlayerID && level.Published)
             {
                 if (!PlayerPrefs.HasKey(saveString))
                 {


### PR DESCRIPTION
Added a method that checks if the current player isn't the level's creator and whether the level is already published. Otherwise no progress towards achievement thresholds is counted and no achievements can be unlocked.

This was done to prohibit players unlocking achievements/ accruing progress towards achievements while play-testing their levels during creation of those levels.