### PR TITLE
Correct Qonfiguration bool description for lever block

### DIFF
--- a/Assets/_Project/ScriptableObjects/Data/Editor/Tiles/LeverBlock.asset
+++ b/Assets/_Project/ScriptableObjects/Data/Editor/Tiles/LeverBlock.asset
@@ -20,4 +20,3 @@ MonoBehaviour:
   <Config>k__BackingField: {fileID: 11400000, guid: 79fc03520b517304eb072a35366ce9ea, type: 2}
   <LevelLimit>k__BackingField: 0
   <IsBackground>k__BackingField: 0
-  <IsQonfigurable>k__BackingField: 0

--- a/Assets/_Project/Scripts/LevelEditor/EditorTileData.cs
+++ b/Assets/_Project/Scripts/LevelEditor/EditorTileData.cs
@@ -26,6 +26,5 @@ namespace Editarrr.LevelEditor
         public bool IsInfinite { get => this.LevelLimit <= 0; }
 
         [field: SerializeField] public bool IsBackground { get; private set; }
-        [field: SerializeField] public bool IsQonfigurable { get; private set; }
     }
 }

--- a/Assets/_Project/Scripts/LevelEditor/Tiles/Configs/LeverBlockConfig.cs
+++ b/Assets/_Project/Scripts/LevelEditor/Tiles/Configs/LeverBlockConfig.cs
@@ -16,7 +16,7 @@
         public LeverBlockConfig(int[] data)
         {
             this.Channel = data[0];
-            this.Inverted = data[1] == 1 ? true : false;
+            this.Inverted = data[1] == 1;
         }
 
         protected override int[] GetJSONData()
@@ -35,7 +35,7 @@
             var channelElement = getElement("Channel", this.Channel);
             channelElement.RegisterCallback<UnityEngine.UIElements.ChangeEvent<string>>(this.SetChannel_Callback);
 
-            var invertedElement = getElement("Start as inactive", this.Inverted);
+            var invertedElement = getElement("Start as active", this.Inverted);
             invertedElement.RegisterCallback<UnityEngine.UIElements.ChangeEvent<bool>>(this.SetInverted_Callback);
 
         }


### PR DESCRIPTION
Lever Block Qonfiguration panel now shows "Start as active" instead of "Start as inactive". Inuitively, I wanted the blocks to start active per default, but changing this now would invert the blocks in all already built levels, which cannot be changed by the users, since they've been uploaded already. So I opted for this solution.

Sidenote: I also removed the unused Property "Qonfigurable" from the EditorTileData, which I introduced in a earlier PR by mistake. 

Closes #178