### PR TITLE
By yanniboi: Track totalScores and totalRatings locally when updated.

### DIFF
--- a/Assets/_Project/Scripts/Gameplay/GUI/WinMenu.cs
+++ b/Assets/_Project/Scripts/Gameplay/GUI/WinMenu.cs
@@ -15,8 +15,7 @@ namespace Gameplay.GUI
     {
         public static event Action<string, RemoteScoreStorage_AllScoresLoadedCallback> OnLeaderboardRequested;
 
-        public delegate void WinMenu_OnScoreSubmit();
-        public static event Action<string, float, WinMenu_OnScoreSubmit> OnScoreSubmit;
+        public static event Action<string, float> OnScoreSubmit;
         public static event Action<string, int> OnRatingSubmit;
 
         public TMP_Text LevelCode;
@@ -141,12 +140,7 @@ namespace Gameplay.GUI
         public void SubmitScore()
         {
             Debug.Log("Submitting score");
-            OnScoreSubmit?.Invoke(_code, _time, OnSubmitScoreOpenDashboard);
-
-            void OnSubmitScoreOpenDashboard()
-            {
-                // We dont need this anymore.
-            }
+            OnScoreSubmit?.Invoke(_code, _time);
         }
 
         public void OpenScoreboard()

--- a/Assets/_Project/Scripts/Level/LevelBrowserManager.cs
+++ b/Assets/_Project/Scripts/Level/LevelBrowserManager.cs
@@ -1,3 +1,4 @@
+using System;
 using Browser;
 using Editarrr.Level;
 using Editarrr.Managers;
@@ -13,6 +14,8 @@ public class LevelBrowserManager : ManagerComponent
 {
     private const string Documentation = "This handles loading levels for level browser.";
 
+    public static event Action<LevelStub[]> OnRemoteLevelsLoaded;
+
     [field: SerializeField, Info(Documentation), Header("Managers")] private LevelManager LevelManager { get; set; }
 
     // From system
@@ -23,7 +26,7 @@ public class LevelBrowserManager : ManagerComponent
 
     SortingState _currentSortingState = SortingState.Inactive;
     string _sortingCriterionName = "";
-    
+
 
     public void SetLevelLoader(LevelBrowserLoader levelLoader)
     {
@@ -64,10 +67,12 @@ public class LevelBrowserManager : ManagerComponent
             else
                 orderedlevels = levels.OrderBy(x => x.Code);
 
-           _levelLoader.SetLevels(orderedlevels.ToArray());
+            this._levelLoader.SetLevels(orderedlevels.ToArray());
             this.NextCursor = cursor;
             this.PagerRequestResultHasMoreCallback?.Invoke(levels.Length == this.LevelQuery.limit);
             this.PagerRequestResultHasMoreCallback = null;
+
+            OnRemoteLevelsLoaded?.Invoke(levels);
         }
     }
 
@@ -158,6 +163,8 @@ public class LevelBrowserManager : ManagerComponent
 
     public override void DoOnEnable()
     {
+        this.LevelManager.DoOnEnable();
+
         LevelBrowserLevel.OnBrowserLevelDownload += OnLevelDownloadRequested;
         LevelBrowserLevel.OnBrowserLevelDownloadScreenshot += OnLevelScreenshotDownloadRequested;
         BrowserPager.OnBrowserPagerUpdated += OnBrowserPagerUpdateRequested;
@@ -172,6 +179,8 @@ public class LevelBrowserManager : ManagerComponent
 
     public override void DoOnDisable()
     {
+        this.LevelManager.DoOnDisable();
+
         LevelBrowserLevel.OnBrowserLevelDownload -= OnLevelDownloadRequested;
         LevelBrowserLevel.OnBrowserLevelDownloadScreenshot -= OnLevelScreenshotDownloadRequested;
         BrowserPager.OnBrowserPagerUpdated -= OnBrowserPagerUpdateRequested;

--- a/Assets/_Project/Scripts/Level/LevelPlayManager.cs
+++ b/Assets/_Project/Scripts/Level/LevelPlayManager.cs
@@ -208,22 +208,19 @@ namespace Editarrr.Level
         #endregion
 
 
-        private void OnScoreSubmitRequested(string code, float time, WinMenu.WinMenu_OnScoreSubmit callback)
+        private void OnScoreSubmitRequested(string code, float time)
         {
             this.LevelManager.LevelStorage.LoadLevelData(code, ScoreLevelLoaded);
 
             void ScoreLevelLoaded(LevelSave levelSave)
             {
                 this.LevelManager.SubmitScore(time, levelSave, ScoreSubmitted);
+                this.LevelManager.TrackNewScore(levelSave);
 
                 void ScoreSubmitted(string code, string remoteId, bool isSteam)
                 {
-                    // @todo do we need this?
                     AchievementManager.Instance.UnlockAchievement(GameAchievement.LevelScoreSubmitted);
                     AnalyticsManager.Instance.TrackEvent(AnalyticsEvent.LevelScoreSubmitted, $"{code}-{time}");
-
-                    // Update leaderboard.
-                    callback.Invoke();
                 }
             }
         }
@@ -234,7 +231,8 @@ namespace Editarrr.Level
 
             void RatingLevelLoaded(LevelSave levelSave)
             {
-                LevelManager.SubmitRating(rating, levelSave, RatingSubmitted);
+                this.LevelManager.SubmitRating(rating, levelSave, RatingSubmitted);
+                this.LevelManager.TrackNewRating(levelSave);
 
                 void RatingSubmitted(string code, string remoteId, bool isSteam)
                 {

--- a/Assets/_Project/Scripts/Level/LevelSave.cs
+++ b/Assets/_Project/Scripts/Level/LevelSave.cs
@@ -93,6 +93,12 @@ namespace Editarrr.Level
             this.Tiles = tiles.ToArray();
         }
 
+        public bool IsDistro()
+        {
+            // @todo Should we store this property properly?
+            return this.Code.ToLower().Contains("demo");
+        }
+
         public string[] GetLabels()
         {
             return this.Labels.ToArray();

--- a/Assets/_Project/Scripts/Level/LevelSelectionManager.cs
+++ b/Assets/_Project/Scripts/Level/LevelSelectionManager.cs
@@ -258,6 +258,8 @@ public class LevelSelectionManager : ManagerComponent
 
     public override void DoOnEnable()
     {
+        this.LevelManager.DoOnEnable();
+
         EditorLevel.OnEditorLevelSelected += OnLevelSelected;
         EditorLevel.OnEditorLevelPlayRequest += OnLevelPlayRequested;
         EditorLevel.OnEditorLevelDelete += OnLevelDeleted;
@@ -270,6 +272,8 @@ public class LevelSelectionManager : ManagerComponent
 
     public override void DoOnDisable()
     {
+        this.LevelManager.DoOnDisable();
+
         EditorLevel.OnEditorLevelSelected -= OnLevelSelected;
         EditorLevel.OnEditorLevelPlayRequest -= OnLevelPlayRequested;
         EditorLevel.OnEditorLevelDelete -= OnLevelDeleted;

--- a/Assets/_Project/Scripts/Level/Storage/ILevelStorage.cs
+++ b/Assets/_Project/Scripts/Level/Storage/ILevelStorage.cs
@@ -8,7 +8,7 @@ namespace Level.Storage
          * Optional setup tasks for the storage mechanism.
          */
         public void Initialize();
-        public void Save(string code, string data);
+        public void Save(string code, string data, bool isDistro = false);
         public void SaveScreenshot(string code, byte[] screenshot);
         public string GetUniqueCode();
         public void LoadLevelData(string code, LevelStorage_LevelLoadedCallback callback);

--- a/Assets/_Project/Scripts/Level/Storage/LevelStorageManager.cs
+++ b/Assets/_Project/Scripts/Level/Storage/LevelStorageManager.cs
@@ -4,7 +4,7 @@ namespace Level.Storage
 {
     public abstract class LevelStorageManager : ScriptableObject, ILevelStorage
     {
-        public abstract void Save(string code, string data);
+        public abstract void Save(string code, string data, bool isDistro = false);
         public abstract void SaveScreenshot(string code, byte[] screenshot);
         public abstract string GetScreenshotPath(string code, bool isDistro = false);
         public abstract bool LevelExists(string code);

--- a/Assets/_Project/Scripts/Level/Storage/LocalLevelStorageManager.cs
+++ b/Assets/_Project/Scripts/Level/Storage/LocalLevelStorageManager.cs
@@ -85,10 +85,19 @@ namespace Editarrr.Level
             }
         }
 
-        public override void Save(string code, string data)
+        public override void Save(string code, string data, bool isDistro = false)
         {
             code = code.ToLower();
-            string path = this.GetCreateLevelPath(code) + "level.json";
+            string path = "";
+
+            if (isDistro)
+            {
+                path = this.GetDistroLevelPath(code) + "level.json";
+            }
+            else
+            {
+                path = this.GetCreateLevelPath(code) + "level.json";
+            }
 
             // Write to local storage
             File.WriteAllText(path, data);

--- a/Assets/_Project/Scripts/LevelEditor/EditorLevel/EditorLevelManager.cs
+++ b/Assets/_Project/Scripts/LevelEditor/EditorLevel/EditorLevelManager.cs
@@ -541,7 +541,7 @@ namespace Editarrr.LevelEditor
                 this.Overlays = overlays;
 
                 this.SetScale(newWidth, newHeight);
-                this.TranslateOverlays(expandByX, expandByY); 
+                this.TranslateOverlays(expandByX, expandByY);
             }
         }
 
@@ -805,12 +805,16 @@ namespace Editarrr.LevelEditor
 
         public override void DoOnEnable()
         {
+            this.LevelManager.DoOnEnable();
+
             LevelEditorScreen.SaveAndPlayComponent.OnInvalidLevelRequest += ShowInvalidLevelModal;
             AchievementManager.OnShowAchievement += OnShowAchievement;
         }
 
         public override void DoOnDisable()
         {
+            this.LevelManager.DoOnDisable();
+
             LevelEditorScreen.SaveAndPlayComponent.OnInvalidLevelRequest -= ShowInvalidLevelModal;
             AchievementManager.OnShowAchievement -= OnShowAchievement;
         }


### PR DESCRIPTION
This change locally caches all the totalScores and totalRatings for all levels in the LevelLoader, and if the level browser is opened it checks all the remote levels to see if they are different to the cache. If they are different the local level save is updated.