### PR TITLE
Backend: Level API Name/Code Filter Option

### DIFF
--- a/backend/lambda/api/levels.mjs
+++ b/backend/lambda/api/levels.mjs
@@ -1,5 +1,5 @@
 import { LevelsSortOptions } from "../db/levels.mjs";
-import { BadRequestException, asBool, extractId } from "../utils.mjs";
+import { BadRequestException, asBool, extractId, isArrayOfStrings, isString } from "../utils.mjs";
 
 const defaultPageLimit = 10;
 
@@ -38,6 +38,14 @@ export class LevelsApi {
         if (requestUseDrafts !== undefined) {
             useDrafts = asBool(requestUseDrafts);
             if (useDrafts === undefined) throw new BadRequestException(`'draft' must be either 'true' or 'false'`);
+        }
+
+        if (requestFilters?.anyOfLabels !== undefined) {
+            if (!isArrayOfStrings(requestFilters?.anyOfLabels)) throw new BadRequestException(`'anyOfLabels' must be a comma-separated list of strings. E.g. 'anyOfLabels=test,GDFG'`);
+        }
+
+        if (requestFilters?.nameContains !== undefined) {
+            if (!isString(requestFilters?.nameContains)) throw new BadRequestException(`'nameContains' must be a string`);
         }
 
         var queryResponse = await this.levelsDbClient.getPagedLevels(

--- a/backend/lambda/api/scores.test.mjs
+++ b/backend/lambda/api/scores.test.mjs
@@ -201,9 +201,7 @@ describe('PostScore', function () {
 
             expect.fail('Expected to throw BadRequestException but did not throw any exception.');
         } catch (error) {
-            // Assert that the caught error is an instance of BadRequestException
             expect(error).to.be.an.instanceOf(BadRequestException);
-            // Optionally, assert the error message
             expect(error.message).to.equal("error - Bad Request: 'score' must be a number");
         }
     });

--- a/backend/lambda/function.mjs
+++ b/backend/lambda/function.mjs
@@ -126,6 +126,7 @@ export const handler = async (event, context) => {
             case "GET /levels":
                 var filters = {
                     anyOfLabels: event?.queryStringParameters?.["any-of-labels"]?.split(","),
+                    nameContains: event?.queryStringParameters?.["nameContains"],
                 };
                 responseBody = await levelsApi.getPagedLevels(
                     event?.queryStringParameters?.["sort-option"],

--- a/backend/lambda/utils.mjs
+++ b/backend/lambda/utils.mjs
@@ -36,9 +36,23 @@ export function uuidv4() {
     );
 }
 
+export function isString(x) {
+    return typeof x === 'string'
+}
+
 export function isArrayOfStrings(x) {
     if (!Array.isArray(x)) {
         return false;
     }
-    return x.every(item => typeof item === 'string');
+    return x.every(item => isString(item));
+}
+
+export function andExpression(s1, s2) {
+    if (s1 === undefined) {
+        return s2;
+    }
+    if (s2 === undefined) {
+        return s1;
+    }
+    return `(${s1}) AND (${s2})`
 }

--- a/backend/requests/levels/get-all.sh
+++ b/backend/requests/levels/get-all.sh
@@ -37,6 +37,14 @@ echo "Getting the levels with the most ratings"
 curl ${URL}?'sort-option=total-ratings&sort-asc=false&limit='${LIMIT} | python3 -m json.tool
 echo
 
-echo "Getting levels that have the 'test' label"
+echo "Getting levels that have the 'test' or 'GDFG' labels"
 curl ${URL}?'any-of-labels=test,GDFG' | python3 -m json.tool
+echo
+
+echo "Getting levels that have '2' in their name"
+curl ${URL}?'nameContains=2' | python3 -m json.tool
+echo
+
+echo "Getting levels that have the 'test' or 'GDFG' labels AND have '2' in their name"
+curl ${URL}?'any-of-labels=test,GDFG&nameContains=2' | python3 -m json.tool
 echo

--- a/backend/requests/levels/post.sh
+++ b/backend/requests/levels/post.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 
 curl -X "POST" -H "Content-Type: application/json" -d \
     '{
-        "name": "Murphys Dads Test Level", 
+        "name": "12345", 
         "creator": {
             "id": "2cbe4992-950e-43bc-9fec-4e6138b5ce74",
             "name": "Murphys dad"

--- a/backend/scripts/query-ddb.sh
+++ b/backend/scripts/query-ddb.sh
@@ -54,6 +54,7 @@ TABLE=editarrr-level-storage
 #     --update-expression "SET levelAvgScore = :avgScore, levelTotalScores = :totalScores" \
 #     --expression-attribute-values '{":avgScore": {"N": "1.5"}, ":totalScores": {"N": "1"}}'
 
+# https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html
 # Get Levels with at least one of the queried labels
 # aws dynamodb query \
 #   --table-name $TABLE \
@@ -64,3 +65,15 @@ TABLE=editarrr-level-storage
 #   --key-condition-expression "levelStatus = :status" \
 #   --filter-expression "contains(labels, :label1) OR contains(labels, :label2)" \
 #   --expression-attribute-values '{ ":status": { "S": "PUBLISHED" }, ":label1": { "S": "test" }, ":label2": { "S": "GDFG" } }'
+
+# https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html
+# Get Levels with at least one of the queried labels AND the levelName is a substring match
+# aws dynamodb query \
+#   --table-name $TABLE \
+#   --index-name "levelStatus-levelUpdatedAt-index" \
+#   --select "ALL_PROJECTED_ATTRIBUTES" \
+#   --limit 10 \
+#   --no-scan-index-forward \
+#   --key-condition-expression "levelStatus = :status" \
+#   --filter-expression "(contains(labels, :label1) OR contains(labels, :label2)) AND contains(levelName, :nameSubstring)" \
+#   --expression-attribute-values '{ ":status": { "S": "PUBLISHED" }, ":label1": { "S": "test" }, ":label2": { "S": "GDFG" }, ":nameSubstring": { "S": "2" } }'


### PR DESCRIPTION
https://github.com/LPGameDevs/EditarrrPublic/issues/224

Also, moved validation of `filters` to the "API layer" (rather than in the DB client) to be consistent with the rest of the validations

- [x] Deployed and tested in 'dev' env
- [ ] Front end testing in game UI
- [ ] Deployed in 'prod' env