### PR TITLE
Backend: [Bug Fix] Artificial Pagination when DDB FilterExpression is used (instead of 'limit')

### DIFF
--- a/backend/lambda/db/scores.mjs
+++ b/backend/lambda/db/scores.mjs
@@ -78,6 +78,7 @@ export class ScoresDbClient {
             TableName: tableName,
             IndexName: sortOptionToIndex[sortOption],
             Select: "ALL_PROJECTED_ATTRIBUTES",
+            // Note: We should STOP using 'limit' if we introduce a FilterExpression - see https://stackoverflow.com/questions/40138551/how-can-i-do-dynamodb-limit-after-filtering
             Limit: pageLimit,
             ScanIndexForward: sortAsc, 
             KeyConditionExpression: "pk = :levelId",

--- a/backend/requests/levels/get-all.sh
+++ b/backend/requests/levels/get-all.sh
@@ -48,3 +48,7 @@ echo
 echo "Getting levels that have the 'test' or 'GDFG' labels AND have '2' in their name"
 curl ${URL}?'any-of-labels=test,GDFG&nameContains=2' | python3 -m json.tool
 echo
+
+echo "Getting levels paginates correctly even if the 'nameContains' (or other filters that us DDB FilterExpression) is provided (this query should return an level)"
+curl ${URL}?'nameContains=56197' | python3 -m json.tool
+echo

--- a/backend/scripts/query-ddb.sh
+++ b/backend/scripts/query-ddb.sh
@@ -77,3 +77,17 @@ TABLE=editarrr-level-storage
 #   --key-condition-expression "levelStatus = :status" \
 #   --filter-expression "(contains(labels, :label1) OR contains(labels, :label2)) AND contains(levelName, :nameSubstring)" \
 #   --expression-attribute-values '{ ":status": { "S": "PUBLISHED" }, ":label1": { "S": "test" }, ":label2": { "S": "GDFG" }, ":nameSubstring": { "S": "2" } }'
+
+# Get Levels demo that, if there 'limit' cuts off _after_ the FilterExpression is executed
+# From the AWS Doc (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.FilterExpression.html)
+# 'A Query operation can retrieve a maximum of 1 MB of data. This limit applies before the filter expression is evaluated.'
+# Note: the '--max-items' flag in the CLI does what we want, but it is a CLI-only option (https://docs.aws.amazon.com/cli/latest/reference/dynamodb/query.html)
+# aws dynamodb query \
+#   --table-name $TABLE \
+#   --index-name "levelStatus-levelUpdatedAt-index" \
+#   --select "ALL_PROJECTED_ATTRIBUTES" \
+#   --limit 10 \
+#   --no-scan-index-forward \
+#   --key-condition-expression "levelStatus = :status" \
+#   --filter-expression "(contains(levelName, :nameSubstring))" \
+#   --expression-attribute-values '{ ":status": { "S": "PUBLISHED" }, ":nameSubstring": { "S": "56197" } }'


### PR DESCRIPTION
Fixes [this bug](https://github.com/LPGameDevs/EditarrrPublic/pull/225#issuecomment-1856047780) with filtering & pagination

We have to do this because, if we have a FilterExpression,
it first fetches unfiltered items up to the limit,
and _then_ filters that first page,
but doesn't fetch anymore once it's filtered out that page.

From the [AWS Docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.FilterExpression.html):
> 'A Query operation can retrieve a maximum of 1 MB of data.
> This limit applies before the filter expression is evaluated.'

This completes https://github.com/LPGameDevs/EditarrrPublic/issues/224

- [x] Deployed and tested in `dev`
- [ ] Deployed and tested in `production`
