### PR TITLE
Backend: Level Code Sort Option

### DIFF
--- a/backend/lambda/api/levels.test.mjs
+++ b/backend/lambda/api/levels.test.mjs
@@ -759,6 +759,108 @@ describe('GetPagedLevels', function () {
         });
     });
 
+    it('should fetch the first page of levels sorted by level code.', async function () {
+        // Arrange
+        var sortOptionQueryParam = "level-code";
+        var sortAscQueryParam = "false";
+        var limitQueryParam = "2";
+        var cursorQueryParam = undefined;
+        var useDraftsQueryParam = "false";
+
+        ddbClientSendStub.withArgs(match.has("input", {
+            TableName: tableNameLevel,
+            IndexName: "levelStatus-levelName-index",
+            Select: "ALL_PROJECTED_ATTRIBUTES",
+            Limit: 2,
+            ScanIndexForward: false,
+            KeyConditionExpression: "levelStatus = :status",
+            ExpressionAttributeValues: { ":status": "PUBLISHED" },
+        })).returns({
+            "Items":[
+                {
+                    "levelName": "Level 2",
+                    "levelUpdatedAt": 1698514557729,
+                    "levelCreatorId": "user-1-id",
+                    "levelData": {},
+                    "levelStatus": "PUBLISHED",
+                    "sk": "LEVEL#2-2-2-2-2",
+                    "levelCreatedAt": 1698514557729,
+                    "pk": "LEVEL#2-2-2-2-2",
+                    "levelCreatorName": "User 1",
+                    "levelAvgScore": 1.0,
+                    "levelTotalScores": 2,
+                    "levelAvgRating": 1,
+                    "levelTotalRatings": 2,
+                },
+                {
+                    "levelName": "Level 1",
+                    "levelUpdatedAt": 1698514557729,
+                    "levelCreatorId": "user-1-id",
+                    "levelData": {},
+                    "levelStatus": "PUBLISHED",
+                    "sk": "LEVEL#1-1-1-1-1",
+                    "levelCreatedAt": 1698514557729,
+                    "pk": "LEVEL#1-1-1-1-1",
+                    "levelCreatorName": "User 1",
+                    "levelAvgScore": 1.0,
+                    "levelTotalScores": 2,
+                    "levelAvgRating": 1,
+                    "levelTotalRatings": 1,
+                },
+            ] 
+        });
+
+
+        // Act
+        var firstPageOfLevels = await levelsApi.getPagedLevels(
+            sortOptionQueryParam,
+            sortAscQueryParam,
+            limitQueryParam,
+            cursorQueryParam,
+            useDraftsQueryParam,
+        );
+
+        // Assert
+        expect(firstPageOfLevels).to.deep.equal({
+            levels: [
+                {
+                    "id": "2-2-2-2-2",
+                    "name": "Level 2",
+                    "creator": {
+                        "id": "user-1-id",
+                        "name": "User 1",
+                    },
+                    "updatedAt": 1698514557729,
+                    "data": {},
+                    "status": "PUBLISHED",
+                    "createdAt": 1698514557729,
+                    "avgScore": 1.0,
+                    "totalScores": 2,
+                    "avgRating": 1,
+                    "totalRatings": 2,
+                    "labels": [],
+                },
+                {
+                    "id": "1-1-1-1-1",
+                    "name": "Level 1",
+                    "creator": {
+                        "id": "user-1-id",
+                        "name": "User 1",
+                    },
+                    "updatedAt": 1698514557729,
+                    "data": {},
+                    "status": "PUBLISHED",
+                    "createdAt": 1698514557729,
+                    "avgScore": 1.0,
+                    "totalScores": 2,
+                    "avgRating": 1,
+                    "totalRatings": 1,
+                    "labels": [],
+                }
+            ]   
+        });
+    });
+
     it('should fetch the first page of levels, and return a cursor if there are more.', async function () {
         // Arrange
         var sortOptionQueryParam = undefined;

--- a/backend/lambda/db/levels.mjs
+++ b/backend/lambda/db/levels.mjs
@@ -11,6 +11,7 @@ const indexStatusAvgScore = "levelStatus-levelAvgScore-index"
 const indexStatusTotalScores = "levelStatus-levelTotalScores-index";
 const indexStatusAvgRating = "levelStatus-levelAvgRating-index";
 const indexStatusTotalRatings = "levelStatus-levelTotalRatings-index";
+const indexStatusLevelName = "levelStatus-levelName-index";
 
 // Because JS doesn't have enums...
 export class LevelsSortOptions {
@@ -43,6 +44,7 @@ const sortOptionToIndex = {
     [LevelsSortOptions.TOTAL_SCORES]: indexStatusTotalScores,
     [LevelsSortOptions.AVG_RATING]: indexStatusAvgRating,
     [LevelsSortOptions.TOTAL_RATINGS]: indexStatusTotalRatings,
+    [LevelsSortOptions.LEVEL_CODE]: indexStatusLevelName,
 }
 
 const sortOptionToAttributeName = {
@@ -52,6 +54,7 @@ const sortOptionToAttributeName = {
     [LevelsSortOptions.TOTAL_SCORES]: "levelTotalScores",
     [LevelsSortOptions.AVG_RATING]: "levelAvgRating",
     [LevelsSortOptions.TOTAL_RATINGS]: "levelTotalRatings",
+    [LevelsSortOptions.LEVEL_CODE]: "levelName",
 }
 
 export class LevelsDbClient {

--- a/backend/requests/levels/get-all.sh
+++ b/backend/requests/levels/get-all.sh
@@ -37,6 +37,10 @@ echo "Getting the levels with the most ratings"
 curl ${URL}?'sort-option=total-ratings&sort-asc=false&limit='${LIMIT} | python3 -m json.tool
 echo
 
+echo "Getting the levels by code, alpha-numerically sorted ascending"
+curl ${URL}?'sort-option=level-code&sort-asc=true' | python3 -m json.tool
+echo
+
 echo "Getting levels that have the 'test' or 'GDFG' labels"
 curl ${URL}?'any-of-labels=test,GDFG' | python3 -m json.tool
 echo

--- a/backend/terraform/4-dynamodb-table.tf
+++ b/backend/terraform/4-dynamodb-table.tf
@@ -64,11 +64,11 @@ resource "aws_dynamodb_table" "editarrr-level-storage" {
     name = "levelTotalRatings"
     type = "N"
   }
-
-  # attribute {
-  #   name = "levelName"
-  #   type = "S"
-  # }
+  attribute {
+    name = "levelName"
+    type = "S"
+  }
+  
   # attribute {
   #   name = "levelData"
   #   type = "M" # JSON Blob
@@ -148,6 +148,16 @@ resource "aws_dynamodb_table" "editarrr-level-storage" {
     range_key       = "levelTotalRatings"
     projection_type = "INCLUDE"
     non_key_attributes = [ "pk", "levelName", "levelCreatorId", "levelCreatorName", "version", "levelAvgScore", "levelTotalScores", "levelAvgRating", "labels"]
+    write_capacity  = 0
+    read_capacity   = 0
+  }
+
+  global_secondary_index {
+    name            = "levelStatus-levelName-index"
+    hash_key        = "levelStatus"
+    range_key       = "levelName"
+    projection_type = "INCLUDE"
+    non_key_attributes = [ "pk", "levelUpdatedAt", "levelCreatorId", "levelCreatorName", "version", "levelAvgScore", "levelTotalScores", "levelAvgRating", "levelTotalRatings", "labels"]
     write_capacity  = 0
     read_capacity   = 0
   }


### PR DESCRIPTION
Includes a new GSI

- [x] Deployed and tested in `dev`
- [ ] Deployed and tested in `prod`