### PR TITLE
Backend: Level Creator Name Sort Option

### DIFF
--- a/backend/lambda/api/levels.test.mjs
+++ b/backend/lambda/api/levels.test.mjs
@@ -861,6 +861,108 @@ describe('GetPagedLevels', function () {
         });
     });
 
+    it('should fetch the first page of levels sorted by creator name.', async function () {
+        // Arrange
+        var sortOptionQueryParam = "creator-name";
+        var sortAscQueryParam = "false";
+        var limitQueryParam = "2";
+        var cursorQueryParam = undefined;
+        var useDraftsQueryParam = "false";
+
+        ddbClientSendStub.withArgs(match.has("input", {
+            TableName: tableNameLevel,
+            IndexName: "levelStatus-levelCreatorName-index",
+            Select: "ALL_PROJECTED_ATTRIBUTES",
+            Limit: 2,
+            ScanIndexForward: false,
+            KeyConditionExpression: "levelStatus = :status",
+            ExpressionAttributeValues: { ":status": "PUBLISHED" },
+        })).returns({
+            "Items":[
+                {
+                    "levelName": "Level 2",
+                    "levelUpdatedAt": 1698514557729,
+                    "levelCreatorId": "user-2-id",
+                    "levelData": {},
+                    "levelStatus": "PUBLISHED",
+                    "sk": "LEVEL#2-2-2-2-2",
+                    "levelCreatedAt": 1698514557729,
+                    "pk": "LEVEL#2-2-2-2-2",
+                    "levelCreatorName": "User 2",
+                    "levelAvgScore": 1.0,
+                    "levelTotalScores": 2,
+                    "levelAvgRating": 1,
+                    "levelTotalRatings": 2,
+                },
+                {
+                    "levelName": "Level 1",
+                    "levelUpdatedAt": 1698514557729,
+                    "levelCreatorId": "user-1-id",
+                    "levelData": {},
+                    "levelStatus": "PUBLISHED",
+                    "sk": "LEVEL#1-1-1-1-1",
+                    "levelCreatedAt": 1698514557729,
+                    "pk": "LEVEL#1-1-1-1-1",
+                    "levelCreatorName": "User 1",
+                    "levelAvgScore": 1.0,
+                    "levelTotalScores": 2,
+                    "levelAvgRating": 1,
+                    "levelTotalRatings": 1,
+                },
+            ] 
+        });
+
+
+        // Act
+        var firstPageOfLevels = await levelsApi.getPagedLevels(
+            sortOptionQueryParam,
+            sortAscQueryParam,
+            limitQueryParam,
+            cursorQueryParam,
+            useDraftsQueryParam,
+        );
+
+        // Assert
+        expect(firstPageOfLevels).to.deep.equal({
+            levels: [
+                {
+                    "id": "2-2-2-2-2",
+                    "name": "Level 2",
+                    "creator": {
+                        "id": "user-2-id",
+                        "name": "User 2",
+                    },
+                    "updatedAt": 1698514557729,
+                    "data": {},
+                    "status": "PUBLISHED",
+                    "createdAt": 1698514557729,
+                    "avgScore": 1.0,
+                    "totalScores": 2,
+                    "avgRating": 1,
+                    "totalRatings": 2,
+                    "labels": [],
+                },
+                {
+                    "id": "1-1-1-1-1",
+                    "name": "Level 1",
+                    "creator": {
+                        "id": "user-1-id",
+                        "name": "User 1",
+                    },
+                    "updatedAt": 1698514557729,
+                    "data": {},
+                    "status": "PUBLISHED",
+                    "createdAt": 1698514557729,
+                    "avgScore": 1.0,
+                    "totalScores": 2,
+                    "avgRating": 1,
+                    "totalRatings": 1,
+                    "labels": [],
+                }
+            ]   
+        });
+    });
+
     it('should fetch the first page of levels, and return a cursor if there are more.', async function () {
         // Arrange
         var sortOptionQueryParam = undefined;

--- a/backend/lambda/db/levels.mjs
+++ b/backend/lambda/db/levels.mjs
@@ -12,6 +12,7 @@ const indexStatusTotalScores = "levelStatus-levelTotalScores-index";
 const indexStatusAvgRating = "levelStatus-levelAvgRating-index";
 const indexStatusTotalRatings = "levelStatus-levelTotalRatings-index";
 const indexStatusLevelName = "levelStatus-levelName-index";
+const indexStatusLevelCreatorName = "levelStatus-levelCreatorName-index";
 
 // Because JS doesn't have enums...
 export class LevelsSortOptions {
@@ -22,6 +23,7 @@ export class LevelsSortOptions {
     static AVG_RATING = "avg-rating";
     static TOTAL_RATINGS = "total-ratings";
     static LEVEL_CODE = "level-code";
+    static CREATOR_NAME = "creator-name";
 
     static isValid(str) {
         for (const validOption in LevelsSortOptions) {
@@ -45,6 +47,7 @@ const sortOptionToIndex = {
     [LevelsSortOptions.AVG_RATING]: indexStatusAvgRating,
     [LevelsSortOptions.TOTAL_RATINGS]: indexStatusTotalRatings,
     [LevelsSortOptions.LEVEL_CODE]: indexStatusLevelName,
+    [LevelsSortOptions.CREATOR_NAME]: indexStatusLevelCreatorName,
 }
 
 const sortOptionToAttributeName = {
@@ -55,6 +58,7 @@ const sortOptionToAttributeName = {
     [LevelsSortOptions.AVG_RATING]: "levelAvgRating",
     [LevelsSortOptions.TOTAL_RATINGS]: "levelTotalRatings",
     [LevelsSortOptions.LEVEL_CODE]: "levelName",
+    [LevelsSortOptions.CREATOR_NAME]: "levelCreatorName"
 }
 
 export class LevelsDbClient {

--- a/backend/requests/levels/get-all.sh
+++ b/backend/requests/levels/get-all.sh
@@ -41,6 +41,10 @@ echo "Getting the levels by code, alpha-numerically sorted ascending"
 curl ${URL}?'sort-option=level-code&sort-asc=true' | python3 -m json.tool
 echo
 
+echo "Getting the levels by creator name, alphabetically sorted ascending"
+curl ${URL}?'sort-option=creator-name&sort-asc=true' | python3 -m json.tool
+echo
+
 echo "Getting levels that have the 'test' or 'GDFG' labels"
 curl ${URL}?'any-of-labels=test,GDFG' | python3 -m json.tool
 echo

--- a/backend/terraform/4-dynamodb-table.tf
+++ b/backend/terraform/4-dynamodb-table.tf
@@ -68,6 +68,10 @@ resource "aws_dynamodb_table" "editarrr-level-storage" {
     name = "levelName"
     type = "S"
   }
+  attribute {
+    name = "levelCreatorName"
+    type = "S"
+  }
   
   # attribute {
   #   name = "levelData"
@@ -158,6 +162,16 @@ resource "aws_dynamodb_table" "editarrr-level-storage" {
     range_key       = "levelName"
     projection_type = "INCLUDE"
     non_key_attributes = [ "pk", "levelUpdatedAt", "levelCreatorId", "levelCreatorName", "version", "levelAvgScore", "levelTotalScores", "levelAvgRating", "levelTotalRatings", "labels"]
+    write_capacity  = 0
+    read_capacity   = 0
+  }
+
+  global_secondary_index {
+    name            = "levelStatus-levelCreatorName-index"
+    hash_key        = "levelStatus"
+    range_key       = "levelCreatorName"
+    projection_type = "INCLUDE"
+    non_key_attributes = [ "pk", "levelName", "levelUpdatedAt", "levelCreatorId", "version", "levelAvgScore", "levelTotalScores", "levelAvgRating", "levelTotalRatings", "labels"]
     write_capacity  = 0
     read_capacity   = 0
   }


### PR DESCRIPTION
Includes a new GSI

- [x] Deployed and tested in `dev`
- [ ] Deployed and tested in `prod`