### PR TITLE
Backend: Score Storage - Remove Vistages of "score" Before "scoreNumber"

### DIFF
--- a/backend/lambda/function.mjs
+++ b/backend/lambda/function.mjs
@@ -513,7 +513,7 @@ export const handler = async (event, context) => {
                     responseScores.push({
                         "scoreId": id,
                         "levelId": levelId,
-                        "score": dbScore.score,
+                        "scoreNumber": dbScore.scoreNumber,
                         "code": dbScore.scoreLevelName,
                         "creator": {
                             "id": dbScore.scoreCreatorId,

--- a/backend/terraform/4-dynamodb-table.tf
+++ b/backend/terraform/4-dynamodb-table.tf
@@ -186,12 +186,6 @@ resource "aws_dynamodb_table" "editarrr-score-storage" {
   # pk: LEVEL#<levelId>
   # sk: SCORE#<score>
 
-  # DEPRECATED - use 'scoreNumber' instead. Can get rid of this once we migrate
-  attribute {
-    name = "score"
-    type = "S" # Number of seconds 0015.123
-  }
-
   attribute {
     name = "scoreNumber"
     type = "N" # Number of seconds, e.g. 10.1234
@@ -217,17 +211,6 @@ resource "aws_dynamodb_table" "editarrr-score-storage" {
   #   name = "ghost"
   #   type = "M" # JSON Blob
   # }
-
-  # DEPRECATED - use scoreLevelName-scoreNumber-index instead. Can get rid of this once we migrate
-  global_secondary_index {
-    name            = "scoreLevelName-score-index"
-    hash_key        = "pk"
-    range_key       = "score"  // sort key
-    projection_type = "INCLUDE"
-    non_key_attributes = [ "sk", "pk", "scoreLevelName", "scoreCreatorName", "scoreSubmittedAt", "scoreCreatorId"]
-    write_capacity  = 0
-    read_capacity   = 0
-  }
 
   global_secondary_index {
     name            = "scoreLevelName-scoreNumber-index"


### PR DESCRIPTION
We switched from using scores as strings to scores as numbers in the
database so we could run numerical operations on the keys (like proper
sorting): https://github.com/LPGameDevs/EditarrrPublic/pull/187

This PR removes the remaining bits of code leftover from when the
code used a `score` attribute as the string.

We've run [the migration](https://github.com/LPGameDevs/EditarrrPublic/blob/develop/backend/scripts/migrations/score-strings-to-score-numbers.sh)
 in both dev and prod already so we should be good to remove this.
